### PR TITLE
Fix exoplayer event dispatch to better expose state

### DIFF
--- a/android/src/main/kotlin/br/com/suamusica/rxmediaplayer/android/RxExoPlayer.kt
+++ b/android/src/main/kotlin/br/com/suamusica/rxmediaplayer/android/RxExoPlayer.kt
@@ -177,7 +177,6 @@ class RxExoPlayer (
 
           Player.STATE_BUFFERING -> {
             mediaState = MediaPlayerState.BUFFERING
-            //currentMediaItem?.let { stateDispatcher.onNext(LoadingState(it)) }
           }
           Player.STATE_IDLE -> mediaState = MediaPlayerState.IDLE
         }

--- a/domain/src/main/kotlin/br/com/suamusica/rxmediaplayer/domain/RxMediaServiceImpl.kt
+++ b/domain/src/main/kotlin/br/com/suamusica/rxmediaplayer/domain/RxMediaServiceImpl.kt
@@ -163,7 +163,7 @@ internal class RxMediaServiceImpl(
           }
 
 
-  override fun stateChanges(): Observable<MediaServiceState> =
+  override fun  stateChanges(): Observable<MediaServiceState> =
       Observable.merge(rxMediaPlayer.stateChanges(), stateDispatcher)
           .map { it.setRandomizedState(randomized) }
           .map { it.setRepeatModeState(repeatState) }

--- a/domain/src/main/kotlin/br/com/suamusica/rxmediaplayer/domain/Status.kt
+++ b/domain/src/main/kotlin/br/com/suamusica/rxmediaplayer/domain/Status.kt
@@ -1,5 +1,7 @@
 package br.com.suamusica.rxmediaplayer.domain
 
+import java.lang.Exception
+
 sealed class MediaServiceState(open val isRandomized: Boolean? = null, open val repeatState: RepeatState? = null) {
   abstract fun setRandomizedState(isRandomized: Boolean): MediaBoundState
   abstract fun setRepeatModeState(repeatState: RepeatState): MediaBoundState
@@ -56,6 +58,17 @@ data class CompletedState(
     override val isRandomized: Boolean? = null,
     override val repeatState: RepeatState? = null
 ) : MediaBoundState(item, MediaProgress.COMPLETED, isRandomized, repeatState) {
+  override fun setRepeatModeState(repeatState: RepeatState): MediaBoundState = copy(repeatState = repeatState)
+  override fun setRandomizedState(isRandomized: Boolean): MediaBoundState = copy(isRandomized = isRandomized)
+}
+
+data class ErrorState(
+    override val item: MediaItem,
+    override val progress: MediaProgress,
+    override val isRandomized: Boolean? = null,
+    override val repeatState: RepeatState? = null,
+    val exception: Exception
+) : MediaBoundState(item, progress, isRandomized, repeatState) {
   override fun setRepeatModeState(repeatState: RepeatState): MediaBoundState = copy(repeatState = repeatState)
   override fun setRandomizedState(isRandomized: Boolean): MediaBoundState = copy(isRandomized = isRandomized)
 }


### PR DESCRIPTION
Removi o evento loading pro caso do buffer pois ele causava um comportamento esquisito no player. Adicionei um novo estado de erro para quando falta internet ou qualquer erro correlato. Entendo que tendo um estado específico de erro fica mais fácil para os usuários da biblioteca reagirem a ele.  